### PR TITLE
Absolute value of gradients

### DIFF
--- a/class_saliency_extraction.py
+++ b/class_saliency_extraction.py
@@ -60,8 +60,7 @@ diff = bw['data']
 
 
 # Find the saliency map as described in the paper. Normalize the map and assign it to variabe "saliency"
-
-diff -= diff.min()
+diff = np.abs(diff)
 diff /= diff.max()
 diff_sq = np.squeeze(diff)
 saliency = np.amax(diff_sq,axis=0)


### PR DESCRIPTION
As described in Section 3.1 of the paper, you need to take the absolute value of gradients before normalizing it. If you are not doing it, then you are not visualizing those pixels which decrease the class score the most with a small change (this is also a important descriptor).